### PR TITLE
findAll

### DIFF
--- a/src/main/java/com/errorscentral/guiabolso/controller/ErrorController.java
+++ b/src/main/java/com/errorscentral/guiabolso/controller/ErrorController.java
@@ -2,9 +2,15 @@ package com.errorscentral.guiabolso.controller;
 
 import com.errorscentral.guiabolso.entity.Error;
 import com.errorscentral.guiabolso.service.ErrorService;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -33,7 +39,7 @@ public class ErrorController {
                 log.setUserId(error.get().getUserId());
                 log.setLevel(error.get().getLevel());
                 log.setEvent(error.get().getEvent());
-                log.setSystem(error.get().getSystem());
+                log.setEnvironment(error.get().getEnvironment());
                 log.setCreatedDate(error.get().getCreatedDate());
                 log.setDetailsLog(error.get().getDetailsLog());
                 log.setFiled(true);
@@ -62,5 +68,21 @@ public class ErrorController {
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
     }
+    
+    @GetMapping("error")
+    @ApiResponses(value = {@ApiResponse(code = 400, message = "Request Not Done")})
+    @ApiImplicitParams({
+        @ApiImplicitParam(name = "page", value = "Page", required = false, dataType = "int", paramType = "query"),
+        @ApiImplicitParam(name = "size", value = "Errors per page", required = false, dataType = "int", paramType = "query"),
+        @ApiImplicitParam(name = "sort", value = "Sort by", required = false, dataType = "string", paramType = "query", example = "createdDate,asc")
+      })
+	public ResponseEntity<Page<Error>> getAll(@PageableDefault Pageable pageable){
+		try {
+			Page<Error> error = errorService.findAll(pageable);
+			return new ResponseEntity<Page<Error>>(error, HttpStatus.OK);
+		} catch (Exception e) {
+			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+		}
+	}	
 
 }

--- a/src/main/java/com/errorscentral/guiabolso/entity/Error.java
+++ b/src/main/java/com/errorscentral/guiabolso/entity/Error.java
@@ -10,17 +10,16 @@ import java.time.LocalDate;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name="errors")
-public class Error implements Serializable {
-
-    private static final long SerialVersionUID = 1l;
-
+public class Error implements Serializable{
+	
+	private static final long serialVersionUID = 1L;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne
     @JoinColumn(name = "user_id")
-    private User userId;
+    private User user;
 
     @Column
     @NotNull
@@ -35,7 +34,7 @@ public class Error implements Serializable {
     @Column
     @NotNull
     @Size(min = 1, max = 20)
-    private String system;
+    private String environment;
 
     @Column(name = "created_date")
     private LocalDate createdDate;
@@ -63,11 +62,11 @@ public class Error implements Serializable {
     }
 
     public User getUserId() {
-        return userId;
+        return user;
     }
 
-    public void setUserId(User userId) {
-        this.userId = userId;
+    public void setUserId(User user) {
+        this.user = user;
     }
 
     public String getLevel() {
@@ -86,12 +85,12 @@ public class Error implements Serializable {
         this.event = event;
     }
     
-    public String getSystem() {
-        return system;
+    public String getEnvironment() {
+        return environment;
     }
 
-    public void setSystem(String system) {
-        this.system = system;
+    public void setEnvironment(String environment) {
+        this.environment = environment;
     }
 
     public LocalDate getCreatedDate() {

--- a/src/main/java/com/errorscentral/guiabolso/repository/ErrorRepository.java
+++ b/src/main/java/com/errorscentral/guiabolso/repository/ErrorRepository.java
@@ -1,7 +1,10 @@
 package com.errorscentral.guiabolso.repository;
 
 import com.errorscentral.guiabolso.entity.Error;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,5 +12,8 @@ import java.util.Optional;
 @Repository
 public interface ErrorRepository extends JpaRepository <Error, Long> {
 
-    Optional<Error> findById(long id);
+    Optional<Error> findById(Long id);
+    
+    @Query(value = "SELECT id, created_date, details_log, event, filed, level, environment, update_date, user_id FROM errors", nativeQuery = true )
+    Page<Error> findAllErrors(Pageable pageable);
 }

--- a/src/main/java/com/errorscentral/guiabolso/service/ErrorService.java
+++ b/src/main/java/com/errorscentral/guiabolso/service/ErrorService.java
@@ -1,11 +1,14 @@
 package com.errorscentral.guiabolso.service;
 
-import com.errorscentral.guiabolso.entity.Error;
-import com.errorscentral.guiabolso.repository.ErrorRepository;
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
+import com.errorscentral.guiabolso.entity.Error;
+import com.errorscentral.guiabolso.repository.ErrorRepository;
 
 @Service
 public class ErrorService {
@@ -19,5 +22,10 @@ public class ErrorService {
 
     public Error updateError(Error error){
         return errorRepository.save(error);
+    }
+    
+    public Page<Error> findAll(Pageable pageable){
+    	return errorRepository.findAllErrors(pageable);
+    	
     }
 }


### PR DESCRIPTION
Foi implementado o endpoint de pegar todos os erros, paginando eles.
Tem que rever o padrão de escrita ou do BD ou da classe
Tem que arrumar o conteudo que está vindo da paginação para que não traga o usuário inteiro e sim apenas o ID dele.
Acredito que teria que criar uma nova classe ErroPag para que lá seja especificado o conteudo da pagina e utilizar um PageImpl para arrumar o conteúdo: 
https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/domain/PageImpl.html